### PR TITLE
Fixes for #17 to speed up ORDER BY and OFFSET on key and index columns

### DIFF
--- a/src/IDBDatabase.js
+++ b/src/IDBDatabase.js
@@ -33,7 +33,7 @@
                 idbModules.util.throwDOMException(0, "Invalid State error", me.transaction);
             }
             //key INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE
-            var sql = ["CREATE TABLE", idbModules.util.quote(storeName), "(key BLOB", createOptions.autoIncrement ? ", inc INTEGER PRIMARY KEY AUTOINCREMENT" : "PRIMARY KEY", ", value BLOB)"].join(" ");
+            var sql = ["CREATE TABLE", idbModules.util.quote(storeName), "(key TEXT", createOptions.autoIncrement ? ", inc INTEGER PRIMARY KEY AUTOINCREMENT" : "PRIMARY KEY", ", value BLOB)"].join(" ");
             logger.log(sql);
             tx.executeSql(sql, [], function(tx, data){
                 var sql = ["CREATE INDEX", idbModules.util.quote(storeName+'__key'), "ON", idbModules.util.quote(storeName), "(key)"].join(" ");

--- a/src/IDBDatabase.js
+++ b/src/IDBDatabase.js
@@ -36,9 +36,22 @@
             var sql = ["CREATE TABLE", idbModules.util.quote(storeName), "(key BLOB", createOptions.autoIncrement ? ", inc INTEGER PRIMARY KEY AUTOINCREMENT" : "PRIMARY KEY", ", value BLOB)"].join(" ");
             logger.log(sql);
             tx.executeSql(sql, [], function(tx, data){
-                tx.executeSql("INSERT INTO __sys__ VALUES (?,?,?,?)", [storeName, createOptions.keyPath, createOptions.autoIncrement ? true : false, "{}"], function(){
-                    result.__setReadyState("createObjectStore", true);
-                    success(result);
+                var sql = ["CREATE INDEX", idbModules.util.quote(storeName+'__key'), "ON", idbModules.util.quote(storeName), "(key)"].join(" ");
+                logger.log(sql);
+                tx.executeSql(sql, [], function(tx, data) {
+                    if (createOptions.autoIncrement) {
+                        var sql = ["CREATE INDEX", idbModules.util.quote(storeName+'__inc'), "ON", idbModules.util.quote(storeName), "(inc)"].join(" ");
+                        logger.log(sql);
+                        tx.executeSql(sql, [], insertIntoSys, error);
+                    } else {
+                        insertIntoSys(tx, data);
+                    }
+                    function insertIntoSys(tx, data) {
+                        tx.executeSql("INSERT INTO __sys__ VALUES (?,?,?,?)", [storeName, createOptions.keyPath, createOptions.autoIncrement ? true : false, "{}"], function(){
+                            result.__setReadyState("createObjectStore", true);
+                            success(result);
+                        }, error);
+                    }
                 }, error);
             }, error);
         });

--- a/src/IDBIndex.js
+++ b/src/IDBIndex.js
@@ -38,6 +38,9 @@
                 var sql = ["ALTER TABLE", idbModules.util.quote(me.__idbObjectStore.name), "ADD", columnName, "BLOB"].join(" ");
                 logger.log(sql);
                 tx.executeSql(sql, [], function(tx, data){
+                    var sql = ["CREATE INDEX", idbModules.util.quote(me.__idbObjectStore.name+'__'+columnName), "ON", idbModules.util.quote(me.__idbObjectStore.name), "(", columnName, ")"].join(" ");
+                    logger.log(sql);
+                    tx.executeSql(sql, [], function(tx, data){
                     // Once a column is created, put existing records into the index
                     tx.executeSql("SELECT * FROM " + idbModules.util.quote(me.__idbObjectStore.name), [], function(tx, data){
                         (function initIndexForRow(i){
@@ -62,6 +65,7 @@
                                 }, error);
                             }
                         }(0));
+                    }, error);
                     }, error);
                 }, error);
             }, "createObjectStore");

--- a/src/IDBIndex.js
+++ b/src/IDBIndex.js
@@ -35,7 +35,7 @@
                 };
                 // For this index, first create a column
                 me.__idbObjectStore.__storeProps.indexList = JSON.stringify(idxList);
-                var sql = ["ALTER TABLE", idbModules.util.quote(me.__idbObjectStore.name), "ADD", columnName, "BLOB"].join(" ");
+                var sql = ["ALTER TABLE", idbModules.util.quote(me.__idbObjectStore.name), "ADD", columnName, "TEXT"].join(" ");
                 logger.log(sql);
                 tx.executeSql(sql, [], function(tx, data){
                     var sql = ["CREATE INDEX", idbModules.util.quote(me.__idbObjectStore.name+'__'+columnName), "ON", idbModules.util.quote(me.__idbObjectStore.name), "(", columnName, ")"].join(" ");


### PR DESCRIPTION
Here are a few changes to speed up SQL queries that use `ORDER BY` and `OFFSET` on the `key` and the index columns.
1. SQL INDEX are added for the `key` and `inc` columns. If the `inc` column is never sorted by, its index should not be added.
2. `key` and `index` columns have been moved from `BLOB` to `TEXT`. This should speed up `ORDER BY` even more. I'm not familiar with how this will affect collation, if anything, but it's probably no worse than it is already.

These should fix #17.
