### PR TITLE
Don't advance one more after advancing

### DIFF
--- a/src/IDBCursor.js
+++ b/src/IDBCursor.js
@@ -92,7 +92,6 @@
         this.__idbObjectStore.transaction.__addToTransactionQueue(function(tx, args, success, error){
             me.__offset += count;
             me.__find(undefined, tx, function(key, value){
-                me.__offset++;
                 me.key = key;
                 me.value = value;
                 success(me, me.__req);


### PR DESCRIPTION
Right now if you call `advance`, the next callback gets the right item, but the next `continue` moves two steps forward. This is because there is a plus one increment in both the callback of the `advance` and later in the `continue`.

Other code calling `continue` would `advance` one instead. This brings `advance` closer to the behavior of Firefox.

This is part of the WIP for fixing #20.
