### PR TITLE
Fix #20 Advance should not return cursor if there's no key

### DIFF
--- a/src/IDBCursor.js
+++ b/src/IDBCursor.js
@@ -92,7 +92,6 @@
         this.__idbObjectStore.transaction.__addToTransactionQueue(function(tx, args, success, error){
             me.__offset += count;
             me.__find(undefined, tx, function(key, value){
-                me.__offset++;
                 me.key = key;
                 me.value = value;
                 success(me, me.__req);

--- a/src/IDBCursor.js
+++ b/src/IDBCursor.js
@@ -94,7 +94,7 @@
             me.__find(undefined, tx, function(key, value){
                 me.key = key;
                 me.value = value;
-                success(me, me.__req);
+                success(typeof me.key !== "undefined" ? me : undefined, me.__req);
             }, function(data){
                 error(data);
             });


### PR DESCRIPTION
This fixes #20. Just like `continue`, now `advance` will also not return a cursor if there was no resulting key.

This brings `advance` in line with the behavior of Firefox.
