### PR TITLE
Support for ORDER BY DESC based on IDBCursor direction

### DIFF
--- a/src/IDBCursor.js
+++ b/src/IDBCursor.js
@@ -54,7 +54,11 @@
             sql.push("AND " + me.__keyColumnName + " >= ?");
             sqlValues.push(idbModules.Key.encode(me.__lastKeyContinued));
         }
-        sql.push("ORDER BY ", me.__keyColumnName);
+        
+        // Determine the ORDER BY direction based on the cursor.
+        var direction = me.direction == 'prev' || me.direction == 'prevunique' ? 'DESC' : 'ASC';
+        
+        sql.push("ORDER BY " + me.__keyColumnName + " " + direction);
         sql.push("LIMIT 1 OFFSET " + me.__offset);
         idbModules.DEBUG && console.log(sql.join(" "), sqlValues);
         tx.executeSql(sql.join(" "), sqlValues, function(tx, data){


### PR DESCRIPTION
ORDER BY was always ascending, ignoring the IDBCursor direction.
