### PR TITLE
lowerOpen / upperOpen were being interpreted incorrectly

### DIFF
--- a/src/IDBCursor.js
+++ b/src/IDBCursor.js
@@ -37,12 +37,12 @@
         if (me.__range && (me.__range.lower || me.__range.upper)) {
             sql.push("AND");
             if (me.__range.lower) {
-                sql.push(me.__keyColumnName + (me.__range.lowerOpen ? " >=" : " >") + " ?");
+                sql.push(me.__keyColumnName + (me.__range.lowerOpen ? " >" : " >= ") + " ?");
                 sqlValues.push(idbModules.Key.encode(me.__range.lower));
             }
             (me.__range.lower && me.__range.upper) && sql.push("AND");
             if (me.__range.upper) {
-                sql.push(me.__keyColumnName + (me.__range.upperOpen ? " <= " : " < ") + " ?");
+                sql.push(me.__keyColumnName + (me.__range.upperOpen ? " < " : " <= ") + " ?");
                 sqlValues.push(idbModules.Key.encode(me.__range.upper));
             }
         }


### PR DESCRIPTION
Querying with an IDBKeyrange.only() range would fail because the SQL statement issued would contain something like:

"WHERE propertyName NOT NULL AND propertyName > ? AND propertyName < ? ..."

instead of

"WHERE propertyName NOT NULL AND propertyName >= ? AND propertyName <= ? ..."

I fixed the 2 lines where you interpret lowerOpen and upperOpen
