### PR TITLE
StringList additions.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -35,6 +35,9 @@
     var StringList = function(){
         this.length = 0;
         this._items = [];
+        //Internal functions on the prototype have been made non-enumerable below.
+        if (Object.defineProperty)
+            Object.defineProperty(this, '_items', {enumerable:false});
     };
     StringList.prototype = {
         // Interface.
@@ -52,12 +55,22 @@
         push: function(item){
             this._items.push(item);
             this.length += 1;
+            for(var i = 0; i < this._items.length; i++)
+                this[i] = this._items[i];
         },
         splice: function(/*index, howmany, item1, ..., itemX*/){
             this._items.splice.apply(this._items, arguments);
             this.length = this._items.length;
+            for(var i in this)
+                if (i == String(parseInt(i)))
+                  delete this[i];
+            for(var i = 0; i < this._items.length; i++)
+                this[i] = this._items[i];
         }
     };
+    if (Object.defineProperty)
+        for(var i in {'indexOf':false, 'push':false, 'splice':false})
+            Object.defineProperty(StringList.prototype, i, {enumerable:false});
     idbModules.util = {
         "throwDOMException": throwDOMException,
         "callback": callback,


### PR DESCRIPTION
StringList now has its child nodes as numeric-indexed properties.
StringList's implementation-specific properties are non-enumerable. (No effect on Opera before version 12.)
Fixes #50
