### PR TITLE
Bugfix: when adding data indexes are filled with "undefined"

### DIFF
--- a/src/IDBObjectStore.js
+++ b/src/IDBObjectStore.js
@@ -165,7 +165,7 @@
         var indexes = JSON.parse(this.__storeProps.indexList);
         for (var key in indexes) {
             try {
-                paramMap[indexes[key].columnName] = idbModules.Key.encode(eval("value['" + indexes[key].keyPath + "']"));
+				paramMap[indexes[key].columnName] = idbModules.Key.encode(eval("JSON.parse(value)['" + indexes[key].keyPath + "']"));
             } 
             catch (e) {
                 error(e);


### PR DESCRIPTION
When adding data then data in the columns (that represent indexes) was always "undefined" - the reason was that the string "data" wasn't converted to an object before accessing the members.

<b>This fix only fixes <i>inserting</i> of data, updating of the Indexed object member will not be reflected in the data being changed in the column; that's another one to look at!</b>
