### PR TITLE
For Firefox 24, trying to set window.indexedDB throws a property-not-set...

### DIFF
--- a/src/globalVars.js
+++ b/src/globalVars.js
@@ -17,7 +17,9 @@
         }
     }
     
-    window.indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB;
+    try {
+        window.indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB;
+    } catch (e) {/*no-op*/}
     
     if (typeof window.indexedDB === "undefined" && typeof window.openDatabase !== "undefined") {
         window.shimIndexedDB.__useShim();


### PR DESCRIPTION
...table error

In that case, we don't need to do anything anyway, so the error is safe to ignore.  Just catch the exception and move on.
