### PR TITLE
Fix bug in IDBKeyRange::only - it simply didn't work.

### DIFF
--- a/src/IDBKeyRange.js
+++ b/src/IDBKeyRange.js
@@ -17,7 +17,7 @@
     };
     
     IDBKeyRange.only = function(value){
-        return new IDBKeyRange(value, value, true, true);
+        return new IDBKeyRange(value, value, false, false);
     };
     
     IDBKeyRange.lowerBound = function(value, open){


### PR DESCRIPTION
The created range excludes required value - so it cannot work.
Not sure how/where to create test for this.
