### PR TITLE
prevents error in firefox

### DIFF
--- a/src/globalVars.js
+++ b/src/globalVars.js
@@ -17,7 +17,12 @@
         }
     }
     
-    window.indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB;
+    /*
+    prevent error in Firefox
+    */
+    if(!('indexedDB' in window)) {
+        window.indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB;
+    }
     
     if (typeof window.indexedDB === "undefined" && typeof window.openDatabase !== "undefined") {
         window.shimIndexedDB.__useShim();


### PR DESCRIPTION
Very small change to prevent error message (TypeError: setting a property that has only a getter) in firefox
