### PR TITLE
Allow running qunit without saucelabs.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,11 @@ module.exports = function(grunt) {
 			}
 		},
 		qunit: {
-			all: ['http://localhost:9999/test/index.html']
+			all: {
+				options: {
+					urls: ['http://localhost:9999/test/index.html']
+				}
+			}
 		},
 
 		'saucelabs-qunit': {
@@ -79,6 +83,8 @@ module.exports = function(grunt) {
 	var testJobs = ["build", "connect"];
 	if (saucekey !== null) {
 		testJobs.push("saucelabs-qunit");
+	} else {
+		testJobs.push("qunit");
 	}
 
 	grunt.registerTask('test', testJobs);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-contrib-concat": "~0.1.3",
     "grunt-contrib-uglify": "~0.1.1",
     "grunt-contrib-connect": "~0.1.2",
+    "grunt-contrib-qunit": "0.3.0",
     "grunt-saucelabs": "~4.0.0",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-watch": "~0.3.1",

--- a/test/index.html
+++ b/test/index.html
@@ -2,7 +2,7 @@
     <head>
         <title>Testing IndexedDB Shim</title>
         <meta http-equiv="X-UA-Compatible" content="chrome=1">
-        <link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" type="text/css" media="screen" />
+        <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css" type="text/css" media="screen" />
         <style type="text/css">
             .runOption, .browser {
                 font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial, sans-serif;
@@ -26,7 +26,7 @@
                 margin: 0 10px;
             }
         </style>
-        <script type="text/javascript" src="http://code.jquery.com/qunit/git/qunit.js">
+        <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js">
         </script>
         <script type="text/javascript" src = "queuedUnit.js">
         </script>


### PR DESCRIPTION
- Fixed Qunit urls.
- Run qunit with phantomjs when there is no saucelabs key

Not all tests work correctly yet, one crashes and after disabling that one, 3 are having issue.

Edit2: The Nice effect of running this with phantomjs is that it doesn't support indexedDB and that it is actually testing the shim instead of the indexedDB implementation.
