### PR TITLE
Fix for delete missing the next cursor

### DIFF
--- a/src/IDBCursor.js
+++ b/src/IDBCursor.js
@@ -140,6 +140,8 @@
                 idbModules.DEBUG && console.log(sql, key);
                 tx.executeSql(sql, [idbModules.Key.encode(key)], function(tx, data){
                     if (data.rowsAffected === 1) {
+                        // lower the offset or we will miss a row
+                        me.__offset--;
                         success(undefined);
                     }
                     else {


### PR DESCRIPTION
When iterating over a cursor and deleting one, it skips the next one when calling cursor.continue();.
