### PR TITLE
Greater browser compatibility

### DIFF
--- a/dist/IndexedDBShim.js
+++ b/dist/IndexedDBShim.js
@@ -48,11 +48,16 @@ var idbModules = {};
         this.length = 0;
         this._items = [];
         //Internal functions on the prototype have been made non-enumerable below.
-        if (Object.defineProperty) {
-            Object.defineProperty(this, '_items', {
-                enumerable: false
-            });
-        }
+        /**
+         * In some older browsers this function simply hide the property
+         * from the object and the plugin crashes sooner or later.
+         * 
+         * if (Object.defineProperty) {
+         *     Object.defineProperty(this, '_items', {
+         *         enumerable: false
+         *     });
+         * }
+         */
     };
     StringList.prototype = {
         // Interface.
@@ -87,17 +92,22 @@ var idbModules = {};
             }
         }
     };
-    if (Object.defineProperty) {
-        for (var i in {
-            'indexOf': false,
-            'push': false,
-            'splice': false
-        }) {
-            Object.defineProperty(StringList.prototype, i, {
-                enumerable: false
-            });
-        }
-    }
+    /**
+    * In some older browsers this function simply hide the property
+    * from the object and the plugin crashes sooner or later.
+    * 
+    * if (Object.defineProperty) {
+    *     for (var i in {
+    *         'indexOf': false,
+    *         'push': false,
+    *         'splice': false
+    *     }) {
+    *         Object.defineProperty(StringList.prototype, i, {
+    *             enumerable: false
+    *         });
+    *     }
+    * }
+    */
     idbModules.util = {
         "throwDOMException": throwDOMException,
         "callback": callback,

--- a/dist/IndexedDBShim.js
+++ b/dist/IndexedDBShim.js
@@ -49,9 +49,6 @@ var idbModules = {};
         this._items = [];
         //Internal functions on the prototype have been made non-enumerable below.
         /**
-         * In some older browsers this function simply hide the property
-         * from the object and the plugin crashes sooner or later.
-         * 
          * if (Object.defineProperty) {
          *     Object.defineProperty(this, '_items', {
          *         enumerable: false
@@ -93,9 +90,6 @@ var idbModules = {};
         }
     };
     /**
-    * In some older browsers this function simply hide the property
-    * from the object and the plugin crashes sooner or later.
-    * 
     * if (Object.defineProperty) {
     *     for (var i in {
     *         'indexOf': false,


### PR DESCRIPTION
In some older browsers this function simply hide the property from the object and the plugin crashes sooner or later.
