### PR TITLE
Added Android pre-4.4 shimming

### DIFF
--- a/src/globalVars.js
+++ b/src/globalVars.js
@@ -30,7 +30,18 @@
         window.indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB;
     }
     
-    if (typeof window.indexedDB === "undefined" && typeof window.openDatabase !== "undefined") {
+    /*
+    detect browsers with known IndexedDb issues (e.g. Android pre-4.4)
+    */
+    var poorIndexedDbSupport = false;
+    if (navigator.userAgent.match(/Android 2/) || navigator.userAgent.match(/Android 3/) || navigator.userAgent.match(/Android 4\.[0-3]/)) {
+        /* Chrome is an exception. It supports IndexedDb */
+        if (!navigator.userAgent.match(/Chrome/)) {
+            poorIndexedDbSupport = true;
+        }
+    }
+
+    if ((typeof window.indexedDB === "undefined" || poorIndexedDbSupport) && typeof window.openDatabase !== "undefined") {
         window.shimIndexedDB.__useShim();
     }
     else {


### PR DESCRIPTION
Android stock browser pre-4.4 does not support IndexedDb, but unfortunately reports that it does. This change adds a check for Android <4.4 via the userAgent string and automatically enables the shim if needed. Without this, most 4.x browsers will fail to enable the shim and will have a broken IndexedDb exposed.
