### PR TITLE
Fixed "property is readonly" error on older Android Chrome versions

### DIFF
--- a/src/globalVars.js
+++ b/src/globalVars.js
@@ -41,8 +41,11 @@
         if(!window.IDBTransaction){
             window.IDBTransaction = {};
         }
+        /* Some browsers (e.g. Chrome 18 on Android) support IndexedDb but do not allow writing of these properties */
+        try {
         window.IDBTransaction.READ_ONLY = window.IDBTransaction.READ_ONLY || "readonly";
         window.IDBTransaction.READ_WRITE = window.IDBTransaction.READ_WRITE || "readwrite";
+        } catch (e) {}
     }
     
 }(window, idbModules));


### PR DESCRIPTION
Older versions of Chrome on Android do not allow setting of the READ_ONLY property of IDBTransaction, causing a crash in setup. This change wraps them in a small try/catch.
