### PR TITLE
Upgrade node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
 - ./travis.sh before
 - npm install -g grunt-cli
 node_js: 
-- 0.8
+- 0.10
 notifications: 
   email: false
 language: node_js

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "bundleDependencies": [],
   "license": "Apache 2.0",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.10"
   }
 }


### PR DESCRIPTION
TravisCI is failing to run npm install.  I suspect its because its
running an old version of npm.  Upgrading node should fix that
